### PR TITLE
Refactor executeCommand method of ExecutionUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ javafx/
 *.iml
 bin/
 
+# Memory files
+memory
+
+# Test Files
 text-textUi-test/ACTUAL.txt
 text-textUi-test/EXPECTED-UNIX.TXT
 text-textUi-test/memory/*

--- a/src/main/java/bobcat/Main.java
+++ b/src/main/java/bobcat/Main.java
@@ -23,6 +23,7 @@ public class Main extends Application {
             stage.setScene(scene);
             MainWindow mainWindow = fxmlLoader.<MainWindow>getController();
             mainWindow.setExecutor(executor);
+            mainWindow.setStage(stage);
             stage.show();
 
             mainWindow.respondBobCat(new String[]{"Hello! I'm BobCat!", "Trying to remember what happened..."});

--- a/src/main/java/bobcat/exception/BobCatException.java
+++ b/src/main/java/bobcat/exception/BobCatException.java
@@ -1,5 +1,9 @@
 package bobcat.exception;
 
+/**
+ * RuntimeException for BobCat. All unchecked exceptions in BobCat should throw an exception that extends
+ * BobCatException
+ */
 public class BobCatException extends RuntimeException {
     public BobCatException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/bobcat/exception/CommandArityException.java
+++ b/src/main/java/bobcat/exception/CommandArityException.java
@@ -1,5 +1,9 @@
 package bobcat.exception;
 
+/**
+ * A ParserException that is thrown when number of arguments to the command do not match
+ * the expected number of arguments
+ */
 public class CommandArityException extends ParserException {
     public CommandArityException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/bobcat/exception/ExitException.java
+++ b/src/main/java/bobcat/exception/ExitException.java
@@ -1,0 +1,7 @@
+package bobcat.exception;
+
+public class ExitException extends LogicException {
+    public ExitException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/bobcat/exception/InvalidArgumentException.java
+++ b/src/main/java/bobcat/exception/InvalidArgumentException.java
@@ -1,5 +1,8 @@
 package bobcat.exception;
 
+/**
+ * A ParserException that is thrown when the arguments to a command is not understandable by the parser
+ */
 public class InvalidArgumentException extends ParserException {
     public InvalidArgumentException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/bobcat/exception/InvalidOpsException.java
+++ b/src/main/java/bobcat/exception/InvalidOpsException.java
@@ -1,5 +1,8 @@
 package bobcat.exception;
 
+/**
+ * A LogicException that is thrown when the given command cannot be executed
+ */
 public class InvalidOpsException extends LogicException {
     public InvalidOpsException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/bobcat/exception/LogicException.java
+++ b/src/main/java/bobcat/exception/LogicException.java
@@ -1,5 +1,8 @@
 package bobcat.exception;
 
+/**
+ * A BobCatException that is thrown due to errors during execution of a given command
+ */
 public class LogicException extends BobCatException {
     public LogicException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/bobcat/exception/ParserException.java
+++ b/src/main/java/bobcat/exception/ParserException.java
@@ -1,5 +1,8 @@
 package bobcat.exception;
 
+/**
+ * A BobCatException that is thrown due to errors in the parser
+ */
 public class ParserException extends BobCatException {
     public ParserException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/bobcat/exception/UnknownCommandException.java
+++ b/src/main/java/bobcat/exception/UnknownCommandException.java
@@ -1,5 +1,8 @@
 package bobcat.exception;
 
+/**
+ * A ParserException that is thrown when a given command is not recognised by the parser
+ */
 public class UnknownCommandException extends ParserException {
     public UnknownCommandException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/bobcat/executor/command/Command.java
+++ b/src/main/java/bobcat/executor/command/Command.java
@@ -1,0 +1,4 @@
+package bobcat.executor.command;
+
+public interface Command {
+}

--- a/src/main/java/bobcat/executor/command/basic/BasicCommand.java
+++ b/src/main/java/bobcat/executor/command/basic/BasicCommand.java
@@ -1,0 +1,5 @@
+package bobcat.executor.command.basic;
+
+import bobcat.executor.command.Command;
+public abstract class BasicCommand implements Command {
+}

--- a/src/main/java/bobcat/executor/command/basic/Bye.java
+++ b/src/main/java/bobcat/executor/command/basic/Bye.java
@@ -1,0 +1,9 @@
+package bobcat.executor.command.basic;
+
+import bobcat.model.TaskList;
+
+public class Bye extends BasicCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        return new String[]{"Bye! Hope to see you again soon!"};
+    }
+}

--- a/src/main/java/bobcat/executor/command/basic/Find.java
+++ b/src/main/java/bobcat/executor/command/basic/Find.java
@@ -1,0 +1,23 @@
+package bobcat.executor.command.basic;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import bobcat.model.TaskList;
+import bobcat.model.task.Task;
+
+public class Find extends BasicCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        java.util.List<String> initReply = new ArrayList<String>();
+        initReply.add("Here are the matching tasks in your list:");
+        Task[] foundTasks = taskList.findByName(args[1]);
+        initReply.addAll(Stream.iterate(1, x -> x + 1)
+                .limit(foundTasks.length)
+                .map(num -> num.toString() + "." + foundTasks[num - 1])
+                .collect(Collectors.toList()));
+        return initReply.toArray(new String[0]);
+    }
+}
+
+

--- a/src/main/java/bobcat/executor/command/basic/List.java
+++ b/src/main/java/bobcat/executor/command/basic/List.java
@@ -1,0 +1,21 @@
+package bobcat.executor.command.basic;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import bobcat.model.TaskList;
+import bobcat.model.task.Task;
+
+public class List extends BasicCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        java.util.List<String> initialReply = new ArrayList<String>();
+        initialReply.add("Here are the tasks in your list:");
+        Task[] toShow = taskList.getAllTasks();
+        initialReply.addAll(Stream.iterate(1, x -> x + 1)
+                .limit(toShow.length)
+                .map(num -> num.toString() + "." + toShow[num - 1])
+                .collect(Collectors.toList()));
+        return initialReply.toArray(new String[0]);
+    }
+}

--- a/src/main/java/bobcat/executor/command/create/CreationCommand.java
+++ b/src/main/java/bobcat/executor/command/create/CreationCommand.java
@@ -1,0 +1,6 @@
+package bobcat.executor.command.create;
+
+import bobcat.executor.command.Command;
+
+public abstract class CreationCommand implements Command {
+}

--- a/src/main/java/bobcat/executor/command/create/Deadline.java
+++ b/src/main/java/bobcat/executor/command/create/Deadline.java
@@ -1,0 +1,13 @@
+package bobcat.executor.command.create;
+
+import bobcat.model.TaskList;
+import bobcat.model.task.Task;
+
+public class Deadline extends CreationCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        Task addedTask = taskList.push(new bobcat.model.task.Deadline(args[1], args[2]));
+        return new String[]{"Got it. I've added this task:",
+                            "  " + addedTask.toString(),
+                            "Now you have " + taskList.numTasks() + " tasks in the list"};
+    }
+}

--- a/src/main/java/bobcat/executor/command/create/Event.java
+++ b/src/main/java/bobcat/executor/command/create/Event.java
@@ -1,0 +1,13 @@
+package bobcat.executor.command.create;
+
+import bobcat.model.TaskList;
+import bobcat.model.task.Task;
+
+public class Event extends CreationCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        Task addedTask = taskList.push(new bobcat.model.task.Event(args[1], args[2]));
+        return new String[]{"Got it. I've added this task:",
+                            "  " + addedTask.toString(),
+                            "Now you have " + taskList.numTasks() + " tasks in the list"};
+    }
+}

--- a/src/main/java/bobcat/executor/command/create/ToDo.java
+++ b/src/main/java/bobcat/executor/command/create/ToDo.java
@@ -1,0 +1,13 @@
+package bobcat.executor.command.create;
+
+import bobcat.model.TaskList;
+import bobcat.model.task.Task;
+
+public class ToDo extends CreationCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        Task addedTask = taskList.push(new bobcat.model.task.ToDo(args[1]));
+        return new String[]{"Got it. I've added this task:",
+                            "  " + addedTask.toString(),
+                            "Now you have " + taskList.numTasks() + " tasks in the list"};
+    }
+}

--- a/src/main/java/bobcat/executor/command/mutate/Delete.java
+++ b/src/main/java/bobcat/executor/command/mutate/Delete.java
@@ -1,0 +1,13 @@
+package bobcat.executor.command.mutate;
+
+import bobcat.model.TaskList;
+import bobcat.model.task.Task;
+
+public class Delete extends MutationCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        Task deletedTask = taskList.deleteTaskByIdx(Integer.parseInt(args[1]));
+        return new String[]{"Noted. I've removed this task:",
+                            "  " + deletedTask.toString(),
+                            "Now you have " + taskList.numTasks() + " tasks in the list"};
+    }
+}

--- a/src/main/java/bobcat/executor/command/mutate/Done.java
+++ b/src/main/java/bobcat/executor/command/mutate/Done.java
@@ -1,0 +1,11 @@
+package bobcat.executor.command.mutate;
+
+import bobcat.model.TaskList;
+import bobcat.model.task.Task;
+
+public class Done extends MutationCommand {
+    public static String[] execute(TaskList taskList, String... args) {
+        Task markedTask = taskList.markDone(Integer.parseInt(args[1]));
+        return new String[]{"Nice! I've marked this task as done:", "  " + markedTask.toString()};
+    }
+}

--- a/src/main/java/bobcat/executor/command/mutate/MutationCommand.java
+++ b/src/main/java/bobcat/executor/command/mutate/MutationCommand.java
@@ -1,0 +1,6 @@
+package bobcat.executor.command.mutate;
+
+import bobcat.executor.command.Command;
+
+public abstract class MutationCommand implements Command {
+}

--- a/src/main/java/bobcat/executor/parser/QueryParser.java
+++ b/src/main/java/bobcat/executor/parser/QueryParser.java
@@ -12,9 +12,9 @@ import bobcat.exception.UnknownCommandException;
  * sets of commands.
  */
 public class QueryParser {
-    private static final Set<String> taskCreation = Set.of("todo", "event", "deadline");
-    private static final Set<String> taskMarking = Set.of("done", "delete");
-    private static final Set<String> basicCommand = Set.of("list", "find", "bye");
+    private static final Set<String> TASK_CREATION = Set.of("todo", "event", "deadline");
+    private static final Set<String> TASK_MARKING = Set.of("done", "delete");
+    private static final Set<String> BASIC_COMMAND = Set.of("list", "find", "bye");
 
     private final BasicCommandParser basicCommandParser = new BasicCommandParser();
     private final CreationCommandParser taskCreationParser = new CreationCommandParser();
@@ -34,11 +34,11 @@ public class QueryParser {
     public String[] parse(String query) {
         String[] queryArr = query.split("\\s");
         String command = queryArr[0];
-        if (basicCommand.contains(command)) {
+        if (BASIC_COMMAND.contains(command)) {
             return basicCommandParser.parse(command, queryArr);
-        } else if (taskMarking.contains(command)) {
+        } else if (TASK_MARKING.contains(command)) {
             return taskMarkingParser.parse(command, queryArr);
-        } else if (taskCreation.contains(command)) {
+        } else if (TASK_CREATION.contains(command)) {
             return taskCreationParser.parse(command, queryArr);
         }
         throw new UnknownCommandException("I'm sorry, but I don't know what that means :-(");

--- a/src/main/java/bobcat/model/task/Deadline.java
+++ b/src/main/java/bobcat/model/task/Deadline.java
@@ -6,6 +6,9 @@ import java.time.format.DateTimeParseException;
 
 import bobcat.exception.LogicException;
 
+/**
+ * A Task which represents a task with a deadline
+ */
 public class Deadline extends Task {
     protected LocalDate dueDate;
 

--- a/src/main/java/bobcat/model/task/Event.java
+++ b/src/main/java/bobcat/model/task/Event.java
@@ -6,6 +6,9 @@ import java.time.format.DateTimeParseException;
 
 import bobcat.exception.LogicException;
 
+/**
+ * A Task which represents a task with a starting time
+ */
 public class Event extends Task {
     protected LocalDate startTime;
 

--- a/src/main/java/bobcat/model/task/Task.java
+++ b/src/main/java/bobcat/model/task/Task.java
@@ -1,6 +1,6 @@
 package bobcat.model.task;
 
-public class Task {
+public abstract class Task {
     private final String description;
     private boolean isDone;
 
@@ -19,10 +19,6 @@ public class Task {
 
     public void markDone() {
         isDone = true;
-    }
-
-    public void markIncomplete() {
-        isDone = false;
     }
 
     private String getStatus() {

--- a/src/main/java/bobcat/model/task/ToDo.java
+++ b/src/main/java/bobcat/model/task/ToDo.java
@@ -1,5 +1,8 @@
 package bobcat.model.task;
 
+/**
+ * A Task which represents a task with no starting time or deadline
+ */
 public class ToDo extends Task {
 
     public ToDo(String entry, boolean status) {

--- a/src/main/java/bobcat/view/MainWindow.java
+++ b/src/main/java/bobcat/view/MainWindow.java
@@ -5,10 +5,10 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import bobcat.exception.BobCatException;
+import bobcat.exception.ExitException;
 import bobcat.executor.ExecutionUnit;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
@@ -16,6 +16,8 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 
 public class MainWindow extends AnchorPane {
     @FXML
@@ -24,8 +26,6 @@ public class MainWindow extends AnchorPane {
     private VBox dialogContainer;
     @FXML
     private TextField userInput;
-    @FXML
-    private Button sendButton;
 
     private final Image userImage = new Image(Objects.requireNonNull(this.getClass()
                                                         .getResourceAsStream("/images/DaUser.png")));
@@ -33,6 +33,7 @@ public class MainWindow extends AnchorPane {
                                                         .getResourceAsStream("/images/DaBobCat.png")));
 
     private ExecutionUnit executor;
+    private Stage stage;
 
     @FXML
     public void initialize() {
@@ -43,6 +44,10 @@ public class MainWindow extends AnchorPane {
         executor = d;
     }
 
+    public void setStage(Stage s) {
+        stage = s;
+    }
+
     @FXML
     private void handleUserInput(ActionEvent actionEvent) {
         String query = userInput.getText();
@@ -50,6 +55,8 @@ public class MainWindow extends AnchorPane {
 
         try {
             respondBobCat(executor.executeCommand(query));
+        } catch (ExitException e) {
+            stage.fireEvent(new WindowEvent(stage, WindowEvent.WINDOW_CLOSE_REQUEST));
         } catch (BobCatException e) {
             respondError(e);
         } catch (IOException e) {


### PR DESCRIPTION
executeCommand was long and not easy to read.

Shifting mainLogic to a new package increases readibility while
reflecting hierarchy of classes.